### PR TITLE
Minor APIs changes (0.9.1)

### DIFF
--- a/IndomioHTTP.podspec
+++ b/IndomioHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "IndomioHTTP"
-  s.version      = "0.9.0"
+  s.version      = "0.9.1"
   s.summary      = "HTTP client for Swift ages: data encoding/auto deserialization, network metrics, stub, combine and more"
   s.homepage     = "https://github.com/malcommac/IndomioHTTP.git"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Therefore you can create a custom `HTTPClient` to execute all your's webservice 
 
 ```swift
 let jokeAPIClient = HTTPClient(baseURL: "https://official-joke-api.appspot.com")
-let jokesReq = HTTPRequest<User>(.get, "/random_jokes")
+let jokesReq = HTTPRequest<Joke>(.get, "/random_jokes")
                .json(["category": category, "count": countJokes]) // json parameter encoding!
 
 // Instead of callbacks we can also use Combine RX publishers.

--- a/Sources/IndomioHTTP/Request/HTTPRequest+Extensions/Combine/HTTPRequest+Combine.swift
+++ b/Sources/IndomioHTTP/Request/HTTPRequest+Extensions/Combine/HTTPRequest+Combine.swift
@@ -21,7 +21,7 @@ public extension HTTPRequest {
     ///   - client: client in which the request will be executed.
     ///   - queue: queue where the result is called, by default is `main`.
     /// - Returns: AnyPublisher<Object, Error>
-     func future(in client: HTTPClient, queue: DispatchQueue = .main) -> AnyPublisher<Object, Error> {
+     func future(in client: HTTPClient, queue: DispatchQueue = .main) -> AnyPublisher<Object, HTTPError> {
         return Future { [weak self] fulfill in
             self?.run(in: client).onResult(queue, { result in
                 fulfill(result)

--- a/Sources/IndomioHTTP/Request/HTTPRequest+Extensions/Combine/Publishers/HTTPResultPublisher.swift
+++ b/Sources/IndomioHTTP/Request/HTTPRequest+Extensions/Combine/Publishers/HTTPResultPublisher.swift
@@ -18,7 +18,7 @@ import Combine
 extension Combine.Publishers {
     
     public struct HTTPResultPublisher<Object: HTTPDecodableResponse>: Publisher {
-        public typealias Output = Result<Object, Error>
+        public typealias Output = Result<Object, HTTPError>
         public typealias Failure = Never
         
         // MARK: - Private Properties
@@ -37,7 +37,7 @@ extension Combine.Publishers {
         
         // MARK: - Conformance to Publisher
         
-        public func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, Result<Object, Error> == S.Input {
+        public func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, Result<Object, HTTPError> == S.Input {
             let subscription = HTTPResultSubscription(subscriber: subscriber,
                                                           client: client,
                                                           httpRequest: request,
@@ -51,7 +51,7 @@ extension Combine.Publishers {
 
 // MARK: - HTTPResultSubscription
 
-private final class HTTPResultSubscription<S: Subscriber, Object: HTTPDecodableResponse>: Subscription where S.Input == Result<Object, Error>, S.Failure == Never {
+private final class HTTPResultSubscription<S: Subscriber, Object: HTTPDecodableResponse>: Subscription where S.Input == Result<Object, HTTPError>, S.Failure == Never {
     
     // MARK: - Private Properties
 

--- a/Sources/IndomioHTTP/Request/HTTPRequest.swift
+++ b/Sources/IndomioHTTP/Request/HTTPRequest.swift
@@ -155,7 +155,7 @@ open class HTTPRequest<Object: HTTPDecodableResponse>: HTTPRequestProtocol {
     ///   - method: method for http.
     ///   - route: route name.
     required
-    public init(_ method: HTTPMethod = .get, _ route: String = "") {
+    public init(_ method: HTTPMethod = .get, route: String = "") {
         self.method = method
         self.route = route
     }

--- a/Sources/IndomioHTTP/Request/HTTPRequest.swift
+++ b/Sources/IndomioHTTP/Request/HTTPRequest.swift
@@ -21,7 +21,7 @@ public typealias HTTPRawRequest = HTTPRequest<HTTPRawResponse>
 
 /// Defines the generic request you can execute in a client.
 open class HTTPRequest<Object: HTTPDecodableResponse>: HTTPRequestProtocol {
-    public typealias HTTPRequestResult = Result<Object, Error>
+    public typealias HTTPRequestResult = Result<Object, HTTPError>
     public typealias ResultCallback = ((HTTPRequestResult) -> Void)
     public typealias ProgressCallback = ((HTTPProgress) -> Void)
     

--- a/Sources/IndomioHTTP/Request/HTTPRequestProtocol.swift
+++ b/Sources/IndomioHTTP/Request/HTTPRequestProtocol.swift
@@ -107,7 +107,7 @@ public protocol HTTPRequestProtocol: AnyObject {
     /// - Parameters:
     ///   - method: HTTP method for the request, by default is `.get`.
     ///   - route: route to compose with the base url of the `HTTPClient` where the request is running.
-    init(_ method: HTTPMethod, _ route: String)
+    init(_ method: HTTPMethod, route: String)
     
     /// Initialize a new request with given URI template and variables.
     /// The `route` property will be assigned expanding the variables over the template

--- a/Sources/IndomioHTTP/Response/HTTPDecodableResponse.swift
+++ b/Sources/IndomioHTTP/Response/HTTPDecodableResponse.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 
+// Combination of a decodable response which can be parsed via custom parser or Codable.
+public typealias DecodableResponse = HTTPDecodableResponse & Decodable
+
 // MARK: - HTTPDecodableResponse
 
 /// Allows to customize the decode of an object.
@@ -21,7 +24,7 @@ public protocol HTTPDecodableResponse {
     /// Should return `.objectDecodeFailed` in case of failure.
     ///
     /// - Parameter response: response.
-    static func decode(_ response: HTTPRawResponse) -> Result<Self, Error>
+    static func decode(_ response: HTTPRawResponse) -> Result<Self, HTTPError>
     
 }
 

--- a/Sources/IndomioHTTP/Response/HTTPRawResponse.swift
+++ b/Sources/IndomioHTTP/Response/HTTPRawResponse.swift
@@ -25,7 +25,7 @@ public typealias URLSessionResponse = (urlResponse: URLResponse?, data: HTTPRawD
 // In order to simplify the naming instead of creating `HTTPRequest<HTTPRawResponse>` you
 // can use the typealias `HTTPRawRequest`.
 extension HTTPRawResponse: HTTPDecodableResponse {
-    public static func decode(_ response: HTTPRawResponse) -> Result<HTTPRawResponse, Error> {
+    public static func decode(_ response: HTTPRawResponse) -> Result<HTTPRawResponse, HTTPError> {
         .success(response)
     }
 }


### PR DESCRIPTION
- The error result of the API are now typed from a generic `Error` to a typed `HTTPError`
- `HTTPRequest` init function now explicitly mention the `route` parameter in its signature
- Minor fix for documentation examples